### PR TITLE
Fix sector page bug - missing stock_count attribute

### DIFF
--- a/unified_config.py
+++ b/unified_config.py
@@ -11,7 +11,7 @@ class BaseConfig:
     """Base configuration with all settings"""
     
     # Application Configuration
-    APP_VERSION = "0.0.31"
+    APP_VERSION = "0.0.32"
     
     # API Configuration
     FMP_API_KEY = os.getenv('FMP_API_KEY')


### PR DESCRIPTION
- Update app version to 0.0.32
- Fix get_sector_analysis() to return template-compatible structure
- Add missing ''name'', ''stock_count'', and ''symbols'' fields
- Maintain backward compatibility with existing tests
- Resolves ''dict object has no attribute stock_count'' error

Closes #10